### PR TITLE
Handle LAMMPS lost atoms

### DIFF
--- a/pymatnext/analysis/utils.py
+++ b/pymatnext/analysis/utils.py
@@ -69,12 +69,12 @@ def analyse_T(T, Es, E_min, Vs, extra_vals, log_a, flat_V_prior, N_atoms, kB, n_
 
     (Z_term, shift) = calc_Z_terms(beta, log_a, Es, flat_V_prior, N_atoms, Vs)
 
-    Z = sum(Z_term)
+    Z = np.sum(Z_term)
 
-    U_pot = sum(Z_term*Es) / Z
+    U_pot = np.sum(Z_term*Es) / Z
 
     if N_atoms is not None:
-        N = sum(Z_term*N_atoms) / Z
+        N = np.sum(Z_term*N_atoms) / Z
         n_extra_DOF * N
 
     U = n_extra_DOF / (2.0 * beta) + U_pot + E_min
@@ -82,9 +82,9 @@ def analyse_T(T, Es, E_min, Vs, extra_vals, log_a, flat_V_prior, N_atoms, kB, n_
     Cvp = n_extra_DOF * kB / 2.0 + kB * beta * beta * (sum(Z_term * Es**2) / Z - U_pot**2)
 
     if Vs is not None:
-        V = sum(Z_term*Vs)/Z
-        #thermal_exp = -1.0/V * (sum(Z_term*Vs*Vs)*(-beta)*Z - sum(Z_term*Vs)*sum(Z_term*Vs)*(-beta)) / Z**2
-        thermal_exp = -1.0/V * kB * beta*beta * (sum(Z_term*Vs)*sum(Z_term*Es)/Z - sum(Z_term*Vs*Es)) / Z
+        V = np.sum(Z_term*Vs)/Z
+        #thermal_exp = -1.0/V * (sum(Z_term*Vs*Vs)*(-beta)*Z - np.sum(Z_term*Vs)*sum(Z_term*Vs)*(-beta)) / Z**2
+        thermal_exp = -1.0/V * kB * beta*beta * (sum(Z_term*Vs)*sum(Z_term*Es)/Z - np.sum(Z_term*Vs*Es)) / Z
     else:
         V = None
         thermal_exp = None

--- a/pymatnext/cli/sample.py
+++ b/pymatnext/cli/sample.py
@@ -138,7 +138,8 @@ def sample(args, MPI, NS_comm, walker_comm):
             cur_param_dict[arg_name_final] = arg_val
         else:
             raise ValueError(f"Can't override param of type {type(cur_param_dict[arg_name_final])}") 
-        warnings.warn(f"Overridden params file {arg_name} with {cur_param_dict[arg_name_final]}")
+        if NS_comm.rank == 0:
+            warnings.warn(f"Overridden params file {arg_name} with {cur_param_dict[arg_name_final]}")
 
     params_global = params["global"]
 

--- a/pymatnext/cli/sample.py
+++ b/pymatnext/cli/sample.py
@@ -332,8 +332,8 @@ def sample(args, MPI, NS_comm, walker_comm):
 
         loop_iter += 1
 
-    if clone_history_filename is not None:
-        clone_history_filename.close()
+    if clone_history_file is not None:
+        clone_history_file.close()
 
 
 def main(args_list=None, mpi_finalize=True):

--- a/pymatnext/ns_configs/ase_atoms/__init__.py
+++ b/pymatnext/ns_configs/ase_atoms/__init__.py
@@ -135,6 +135,7 @@ class NSConfig_ASE_Atoms():
         # is called, since some calculator object types cannot be communicated by mpi4py
         self._params_calc = deepcopy(params["calculator"])
         self.calc_type = self._params_calc["type"]
+        self.calc = None
 
         # for temperature
         NSConfig_ASE_Atoms.kB = kB
@@ -241,6 +242,21 @@ class NSConfig_ASE_Atoms():
         """
 
         self.n_att_acc = np.zeros((len(NSConfig_ASE_Atoms._step_size_params), 2), dtype=np.int64)
+
+
+    def end_calculator(self):
+        """Close any existing initialized calculator
+        """
+
+        if self.calc_type == "ASE":
+            pass
+        elif self.calc_type == "LAMMPS":
+            if self.calc is not None:
+                self.calc.close()
+        else:
+            raise NotImplementedError(f"Unknown calculator type {self.calc_type}")
+
+        self.calc = None
 
 
     def init_calculator(self):

--- a/pymatnext/ns_configs/ase_atoms/walks_lammps.py
+++ b/pymatnext/ns_configs/ase_atoms/walks_lammps.py
@@ -159,6 +159,7 @@ def walk_pos_gmc(ns_atoms, Emax, rng):
         warnings.warn(f"LAMMPS ns/gmc run raised exception {exc_str}")
         if "Lost atoms" in exc_str:
             # arrays will now be wrong size, and will fail in next call to set_lammps_from_atoms
+            ns_atoms.end_calculator()
             ns_atoms.init_calculator()
         reject = True
 
@@ -221,6 +222,7 @@ def walk_cell(ns_atoms, Emax, rng):
         warnings.warn(f"LAMMPS ns/cellmc run raised exception {exc_str}")
         if "Lost atoms" in exc_str:
             # arrays will now be wrong size, and will fail in next call to set_lammps_from_atoms
+            ns_atoms.end_calculator()
             ns_atoms.init_calculator()
         failed = True
 

--- a/pymatnext/ns_configs/ase_atoms/walks_lammps.py
+++ b/pymatnext/ns_configs/ase_atoms/walks_lammps.py
@@ -155,7 +155,11 @@ def walk_pos_gmc(ns_atoms, Emax, rng):
         E, F = extract_E_F(ns_atoms.calc, False)
         reject = (E >= Emax)
     except Exception as exc:
-        warnings.warn(f"LAMMPS ns/gmc run raised exception {exc}")
+        exc_str = str(exc)
+        warnings.warn(f"LAMMPS ns/gmc run raised exception {exc_str}")
+        if "Lost atoms" in exc_str:
+            # arrays will now be wrong size, and will fail in next call to set_lammps_from_atoms
+            ns_atoms.init_calculator()
         reject = True
 
     if not reject:
@@ -213,7 +217,11 @@ def walk_cell(ns_atoms, Emax, rng):
         ns_atoms.calc.command(f"run {ns_atoms.walk_traj_len['cell']} post no")
         failed = False
     except Exception as exc:
-        warnings.warn(f"LAMMPS ns/cellmc run raised exception {exc}")
+        exc_str = str(exc)
+        warnings.warn(f"LAMMPS ns/cellmc run raised exception {exc_str}")
+        if "Lost atoms" in exc_str:
+            # arrays will now be wrong size, and will fail in next call to set_lammps_from_atoms
+            ns_atoms.init_calculator()
         failed = True
 
     if not failed:
@@ -228,8 +236,13 @@ def walk_cell(ns_atoms, Emax, rng):
     n_att = {}
     n_acc = {}
     for submove_i, submove_type in enumerate(["volume", "stretch", "shear"]):
-        n_att[submove_type] = int(ns_atoms.calc.extract_fix("NS", lammps.LMP_STYLE_GLOBAL, lammps.LMP_TYPE_VECTOR, 2 * submove_i + 0, 0))
-        n_acc[submove_type] = int(ns_atoms.calc.extract_fix("NS", lammps.LMP_STYLE_GLOBAL, lammps.LMP_TYPE_VECTOR, 2 * submove_i + 1, 0))
+        try:
+            n_att[submove_type] = int(ns_atoms.calc.extract_fix("NS", lammps.LMP_STYLE_GLOBAL, lammps.LMP_TYPE_VECTOR, 2 * submove_i + 0, 0))
+            n_acc[submove_type] = int(ns_atoms.calc.extract_fix("NS", lammps.LMP_STYLE_GLOBAL, lammps.LMP_TYPE_VECTOR, 2 * submove_i + 1, 0))
+        except Exception as exc:
+            warnings.warn(f"LAMMPS extract_fix failed with {exc}, ignoring")
+            n_att[submove_type] = 0
+            n_acc[submove_type] = 0
 
     return [("cell_volume_per_atom", n_att["volume"], n_acc["volume"]),
             ("cell_shear", n_att["shear"], n_acc["shear"]),


### PR DESCRIPTION
restart LAMMPS if a trajectory (gmc or cell) lost atoms, otherwise arrays received from LAMMPS won't be of correct size.  Can probably be done without creating entirely new lammps object, but for now just do it the simple way.