### PR TITLE
Fix bug in step size tuning having to do with order of attempt/successs counts

### DIFF
--- a/pymatnext/ns_configs/ase_atoms/walks_ase_calc.py
+++ b/pymatnext/ns_configs/ase_atoms/walks_ase_calc.py
@@ -18,6 +18,10 @@ def walk_pos_gmc(ns_atoms, Emax, rng):
         maximum shifted energy
     rng: numpy.Generator
         random number generator
+
+    Returns
+    -------
+    [("pos_gmc_each_atom", int n_attempt, int n_success)] info on move params and attempts/successes
     """
     atoms = ns_atoms.atoms
     # new random velocities
@@ -119,6 +123,10 @@ def walk_cell(ns_atoms, Emax, rng):
         maximum shifted energy
     rng: numpy.Generator
         random number generator
+
+    Returns
+    -------
+    [("cell_volume_per_atom", int n_attempt, int n_success), ("cell_shear", ...), ("cell_stretch", ...)] info on move params and attempts/successes
     """
     atoms = ns_atoms.atoms
     N_atoms = len(atoms)
@@ -204,6 +212,10 @@ def walk_type(ns_atoms, Emax, rng):
         maximum shifted energy
     rng: numpy.Generator
         random number generator
+
+    Returns
+    -------
+    [] empty list (nominally cell move param attempt/success)
     """
     atoms = ns_atoms.atoms
     N_atoms = len(atoms)


### PR DESCRIPTION
Switch to keeping track of step_size parameters and attempt/success statistics in dicts, rather than arrays, to reduce chance of inconsistencies in the order.

[may want to add a test that fails under the previous behavior]

closes #24 